### PR TITLE
Added support for changing titles and getting the player list

### DIFF
--- a/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/client/Minecraft.kt
+++ b/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/client/Minecraft.kt
@@ -53,7 +53,7 @@ interface Minecraft {
     // TODO: Add ChatComponent based alternative when that API has been implemented
     fun printChatMessage(message: String)
 
-    fun setTitle(title: String)
+    fun setWindowTitle(title: String)
 
     companion object {
 

--- a/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/client/Minecraft.kt
+++ b/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/client/Minecraft.kt
@@ -53,9 +53,12 @@ interface Minecraft {
     // TODO: Add ChatComponent based alternative when that API has been implemented
     fun printChatMessage(message: String)
 
+    fun setTitle(title: String)
+
     companion object {
 
         val minecraft: Minecraft
             get() = MinecraftApi.getAdapter().minecraft
     }
+
 }

--- a/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/world/World.kt
+++ b/minecraftapi-core/src/main/kotlin/pw/stamina/minecraftapi/game/world/World.kt
@@ -25,8 +25,11 @@
 package pw.stamina.minecraftapi.game.world
 
 import pw.stamina.minecraftapi.game.entity.Entity
+import pw.stamina.minecraftapi.game.entity.living.Player
 
 interface World {
 
     val loadedEntities: List<Entity>
+
+    val loadedPlayers: List<Player>
 }


### PR DESCRIPTION
The World interface now has a variable to get all of the loaded player list.
The Minecraft#setTitle method is needed due to pre-1.13 using LWJGL 2.9.x and post-1.13 using LWJGL 3.3.x, and they're not compatible in terms of changing the title.